### PR TITLE
Fix: Read XDG_DATA_HOME first

### DIFF
--- a/dmenu_drun
+++ b/dmenu_drun
@@ -77,7 +77,7 @@ def get_apps():
     XDG_DATA_DIRS = XDG_DATA_DIRS.split(":")
 
     apps = {}
-    for data_dir in [*XDG_DATA_DIRS, XDG_DATA_HOME]:
+    for data_dir in [XDG_DATA_HOME, *XDG_DATA_DIRS]:
         app_dir = os.path.join(data_dir, 'applications')
         if not os.path.exists(app_dir) or not os.path.isdir(app_dir):
             continue


### PR DESCRIPTION
Previously the program read XDG_DATA_HOME after reading XDG_DATA_DIRS,
ignoring user's custom desktop entry files.