### PR TITLE
Fix: Show desktop entries with a valid TryExec key

### DIFF
--- a/dmenu_drun
+++ b/dmenu_drun
@@ -105,8 +105,8 @@ def if_show(entry):
         return False
     if entry.get('NoDisplay') == 'true' or entry.get('Hidden') == 'true':
         return False
-    if entry.get('TryExec') and shutil.which(entry.get('TryExec')):
-        return False
+    if entry.get('TryExec') and shutil.which(entry.get('TryExec')) is None:
+        return False 
     if not args.ignore_de:
         NotShowIn = entry.get('NotShowIn')
         if NotShowIn and len(set(NotShowIn.split(';')).intersection(current_desktops)) > 0:


### PR DESCRIPTION
Previously, entries with a valid TryExec key where left out because of an error on a condition on the if_show function.